### PR TITLE
fix: モーダル表示崩れ

### DIFF
--- a/video/style.css
+++ b/video/style.css
@@ -151,13 +151,13 @@ html {
 モーダルCSS
 ---------------------------------------------------*/
 .modal {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   z-index: 10;
   display: none;
   width: 100%;
-  height: 100vh;
+  height: 100%;
 
   /* 映像に干渉しないで背景をクリックで閉じるために追加 */
   .modal-bg {


### PR DESCRIPTION
ページスクロールした下部のイメージをクリックした場合、モーダルが上部に固定され表示が崩れるのを修正。